### PR TITLE
:memo: add Github Link

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -17,6 +17,10 @@ const siteMetadata = {
       url: `https://twitter.com/knzw_js`
     },
     {
+      name: `Github`,
+      url: `https://github.com/kanazawa-js`
+    },
+    {
       name: `Connpass`,
       url: `https://kanazawajs.connpass.com/`
     }


### PR DESCRIPTION
# 概要

- コミュニティページにGithub Orgに対するリンクがなかったので追加しました。